### PR TITLE
tested on Terraform v1.3.9

### DIFF
--- a/modules/terraform-nso-mpls-vpn/versions.tf
+++ b/modules/terraform-nso-mpls-vpn/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     nso = {
@@ -7,6 +7,4 @@ terraform {
       version = ">= 0.1.0"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }


### PR DESCRIPTION
Faced following issue testing on main:

❯ terraform init
Initializing modules...
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Experiment has concluded
│
│   on modules/terraform-nso-mpls-vpn/versions.tf line 11, in terraform:
│   11:   experiments = [module_variable_optional_attrs]
│
│ Experiment "module_variable_optional_attrs" is no longer available. The final feature corresponding to this experiment differs from the experimental form and is available in the Terraform language from Terraform
│ v1.3.0 onwards.
╵
